### PR TITLE
[RPC] Allow a JSON masternode list to be filtered by address

### DIFF
--- a/src/rpc/masternodes/masternode.cpp
+++ b/src/rpc/masternodes/masternode.cpp
@@ -697,6 +697,7 @@ UniValue masternodelist(const JSONRPCRequest& request)
                 streamInfo <<  mn.addr.ToStringIP() << " " <<
                                mn.addr.ToStringPort() << " " <<
                                EncodeDestination(mn.pubKeyCollateralAddress.GetID()) << " " <<
+                               EncodeDestination(CScriptID(GetScriptForDestination(WitnessV0KeyHash(mn.pubKeyCollateralAddress.GetID())))) << " " <<
                                mn.GetStatus() << " " <<
                                mn.nProtocolVersion << " " <<
                                mn.lastPing.nDaemonVersion << " " <<


### PR DESCRIPTION
Prior to this change, the RPC command to generate a JSON-formatted masternode list could not be filtered by the collateral address. This one-line change adds the collateral address used in the filtering process.